### PR TITLE
Refactor helper class to take into account view lifecycle

### DIFF
--- a/app/src/main/java/com/c23ps266/capstoneprojectnew/ui/HomeFragment.kt
+++ b/app/src/main/java/com/c23ps266/capstoneprojectnew/ui/HomeFragment.kt
@@ -54,11 +54,10 @@ class HomeFragment : Fragment() {
             labelJsonFileName = "tflite_model_labels.json",
             inputMaxLen = 32
         )
-        textClassifierHelper = TextClassifierHelper(requireContext(), modelDetail) {
-            setSearch()
-            setSpeech()
-        }
+        textClassifierHelper = TextClassifierHelper(modelDetail, requireContext())
 
+        setSearch()
+        setSpeech()
         setDisplayName()
 
         binding.btnPlay.setOnClickListener {

--- a/app/src/main/java/com/c23ps266/capstoneprojectnew/util/TextClassifierHelper.kt
+++ b/app/src/main/java/com/c23ps266/capstoneprojectnew/util/TextClassifierHelper.kt
@@ -2,10 +2,15 @@ package com.c23ps266.capstoneprojectnew.util
 
 import android.content.Context
 import android.util.Log
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
 import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.tensorflow.lite.Interpreter
 import org.tensorflow.lite.support.label.Category
@@ -13,31 +18,67 @@ import java.io.FileInputStream
 import java.io.IOException
 import java.nio.MappedByteBuffer
 import java.nio.channels.FileChannel
-import java.util.concurrent.ScheduledThreadPoolExecutor
 
-class TextClassifierHelper(
-    context: Context,
-    private val modelDetail: ModelDetail,
-    onLoadCompleted: TextClassifierHelper.() -> Unit,
-) {
+class TextClassifierHelper : DefaultLifecycleObserver {
     private lateinit var labels: List<String>
     private lateinit var interpreter: Interpreter
+    private lateinit var initJob: Job
 
-    private val executor: ScheduledThreadPoolExecutor = ScheduledThreadPoolExecutor(1)
+    val id = counter++
+    val modelDetail: ModelDetail
 
-    init {
-        Log.d(TAG, "INIT")
-        CoroutineScope(Dispatchers.IO).launch {
-            val (modelFileName,  labelJson) = modelDetail
+    /**
+     * Initialization is done asynchronously.
+     * If initialization is unfinished at the time of TextClassifierHelper.classify function called, It will
+     * block that initialization at that function before continuing.
+     * You can use the other overload if you want to be immediately notified when initialization finished.
+     */
+    constructor(modelDetail: ModelDetail, context: Context) {
+        Log.i(TAG, "($id) INIT")
+        this.modelDetail = modelDetail
+        init(context)
+    }
+
+    /**
+     * Initialization is done asynchronously.
+     * onLoadCompleted will be called at the time initialization completed.
+     * Call this constructor only from onStart or after! If you call it before onStart, it might crash your app!
+     * @param onLoadCompleted will not be called if lifecycle reached DESTROYED state before loading complete
+     * @param lifecycle lifecycle to be observed
+     */
+    constructor(
+        modelDetail: ModelDetail,
+        context: Context,
+        lifecycle: Lifecycle,
+        onLoadCompleted: TextClassifierHelper.() -> Unit,
+    ) {
+        Log.i(TAG, "($id) INIT")
+        this.modelDetail = modelDetail
+        lifecycle.addObserver(this)
+        init(context, onLoadCompleted)
+    }
+
+    private fun init(
+        context: Context,
+        onLoadCompleted: (TextClassifierHelper.() -> Unit)? = null,
+    ) {
+        initJob = CoroutineScope(Dispatchers.IO).launch {
+            val (modelFileName, labelJson) = modelDetail
+
             labels = Gson().fromJson(loadJSONFromAsset(context, labelJson), Array<String>::class.java).toList()
-            Log.d(TAG, "INIT LABELS: $labels")
+            Log.i(TAG, "($id) INIT Labels: $labels")
+
             interpreter = Interpreter(loadModelFile(context, modelFileName)).also {
                 val sigKey = it.signatureKeys[0]
                 val input = it.getSignatureInputs(sigKey).joinToString(" - ")
                 val output = it.getSignatureOutputs(sigKey).joinToString(" - ")
-                Log.d(TAG, "INIT MODEL : sigKey = $sigKey | input = $input | output = $output")
+                Log.i(TAG, "($id) INIT Model : sigKey = $sigKey | input = $input | output = $output")
             }
-            CoroutineScope(Dispatchers.Main).launch { this@TextClassifierHelper.onLoadCompleted() }
+
+            Log.i(TAG, "($id) INIT Completed")
+            if (isActive && onLoadCompleted != null) {
+                CoroutineScope(Dispatchers.Main).launch { this@TextClassifierHelper.onLoadCompleted() }
+            }
         }
     }
 
@@ -51,18 +92,22 @@ class TextClassifierHelper(
         return fileChannel.map(FileChannel.MapMode.READ_ONLY, startOffset, declaredLength)
     }
 
-    fun classify(message: String, onResult: (result: List<Category>) -> Unit) = executor.execute {
-        Log.d(TAG, "Message: $message")
+    fun classify(message: String, onResult: (result: List<Category>) -> Unit) =
+        CoroutineScope(Dispatchers.Default).launch {
+            if (initJob.isActive) {
+                Log.i(TAG, "waiting for init job to complete...")
+                initJob.join()
+            }
 
-        val inputs = message
-        val outputs: Array<FloatArray> = arrayOf(FloatArray(labels.size))
-        interpreter.run(inputs, outputs)
+            val inputs = message
+            val outputs: Array<FloatArray> = arrayOf(FloatArray(labels.size))
+            interpreter.run(inputs, outputs)
 
-        val results = outputs[0].mapIndexed { index, fl ->
-            Category(labels[index], fl)
+            val results = outputs[0].mapIndexed { index, fl ->
+                Category(labels[index], fl)
+            }
+            CoroutineScope(Dispatchers.Main).launch { onResult(results) }
         }
-        CoroutineScope(Dispatchers.Main).launch { onResult(results) }
-    }
 
     data class ModelDetail(
         val modelFileName: String,
@@ -70,8 +115,18 @@ class TextClassifierHelper(
         val inputMaxLen: Int,
     )
 
+
+    override fun onDestroy(owner: LifecycleOwner) {
+        if (!initJob.isCompleted) {
+            initJob.cancel(CancellationException("observed lifecycle ends"))
+            Log.i(TAG, "($id) INIT Job cancelled")
+            owner.lifecycle.removeObserver(this)
+        }
+    }
+
     companion object {
         private const val TAG = "TextClassifierHelper"
+        private var counter: Int = 0
 
         @Throws(IOException::class)
         private fun loadJSONFromAsset(context: Context, filename: String): String {


### PR DESCRIPTION
There are now 2 constructors of this class. User can choose which one suits them. Details are on the comments.

The original code has a bug that is when a view (Fragment or Activity) is destroyed after its onViewCreated invoked and this class constructor is called onViewCreated, the callback that might has some UI updates will be called after onDestroy invoked, which is an illegal action. For example, root view will be null at the time of callback invoked and when you query viewLifecycleOwner somewhere in that callback, it will fail.

The 4 arguments constructor has similar behavior with the original constructor. Except, in this one, we observe the lifecycle of the view passed on to this constructor. While this works, it only works only if the constructor called on onCreate or after that(?).